### PR TITLE
[daffy] LED reordering method added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 docs/build
 *pyc
+
+.idea

--- a/packages/traffic_light/src/traffic_light_node.py
+++ b/packages/traffic_light/src/traffic_light_node.py
@@ -122,7 +122,7 @@ class TrafficLightNode(DTROS):
             Args:
                 unordered_list (:obj:`list`): List to be ordered.
             Returns:
-                ordered_list (:obj: `list`): Permutated list of length ~number_leds.
+                :obj: `list`: Permutated list of length ~number_leds.
         """
         ordering = [0, 4, 1, 3, 2]
         ordered_list = [unordered_list[i] for i in ordering[0:self.parameters["~number_leds"]]]

--- a/packages/traffic_light/src/traffic_light_node.py
+++ b/packages/traffic_light/src/traffic_light_node.py
@@ -86,10 +86,10 @@ class TrafficLightNode(DTROS):
 
         # Build message
         pattern_msg = LEDPattern()
-        pattern_msg.color_list = color_list
+        pattern_msg.color_list = self.to_led_order(color_list)
         pattern_msg.color_mask = self.color_mask
         pattern_msg.frequency = self.parameters["~frequency"]
-        pattern_msg.frequency_mask = frequency_mask
+        pattern_msg.frequency_mask = self.to_led_order(frequency_mask)
 
         self.changePattern(pattern_msg)
 
@@ -115,6 +115,18 @@ class TrafficLightNode(DTROS):
             cycle_duration = self.parameters["~green_time"] + self.parameters["~all_red_time"]
             self.traffic_cycle.shutdown()
             self.traffic_cycle = rospy.Timer(rospy.Duration(cycle_duration), self.change_direction)
+
+    def to_led_order(self, unordered_list):
+        """Change ordering from successive (0,1,2,3,4) to the one expected by the led emitter (0,4,1,3,2)
+
+            Args:
+                unordered_list (:obj:`list`): List to be ordered.
+            Returns:
+                ordered_list (:obj: `list`): Permutated list of length ~number_leds.
+        """
+        ordering = [0, 4, 1, 3, 2]
+        ordered_list = [unordered_list[i] for i in ordering[0:self.parameters["~number_leds"]]]
+        return ordered_list
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

The traffic light package creates masks iteratively in a logic manner 0->1->2->3->4 but the actual led ordering is 0->2->4->3->1. this fixes it until we modify the rest of the code.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change is constrained only to one package, any interfaces to nodes from other packages are maintained

## Tests
- Tested traffic light behavior
## Style compliance
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I checked that this pull request is compliant with the Duckietown code style
- [X ] I checked that this pull request is compliant with the Duckietown code documentation style

## FOR THE REVIEWERS
__IMPORTANT:__ DO NOT CHANGE THIS SECTION!

- [ ] Functionality (is the change necessary and is it implemented in the most appropriate way): @liampaull or @afdaniele
- [ ] Integration testing (verify the tests and run additional if necessary): @?
- [ ] Code style compliance: @surirohit 
- [ ] Documentation compliance: @aleksandarpetrov

_To the reviewers:_ If you deem necessary, request code edits, more tests, documentation update, or additional reviewing. __Do not review your own code!__

_PR Template, last edit 23 Aug 2019_
